### PR TITLE
fix(deps): add typescript devDependency to packages missing tsc (#29)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -27,6 +27,7 @@
     "@resonance/typescript-config": "workspace:*",
     "@types/node": "^22.0.0",
     "drizzle-kit": "^0.28.0",
-    "eslint": "^10.0.2"
+    "eslint": "^10.0.2",
+    "typescript": "^5"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@resonance/eslint-config": "workspace:*",
     "@resonance/typescript-config": "workspace:*",
-    "eslint": "^10.0.2"
+    "eslint": "^10.0.2",
+    "typescript": "^5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       eslint:
         specifier: ^10.0.2
         version: 10.0.2(jiti@2.6.1)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
   packages/eslint-config:
     dependencies:
@@ -228,6 +231,9 @@ importers:
       eslint:
         specifier: ^10.0.2
         version: 10.0.2(jiti@2.6.1)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
   packages/typescript-config: {}
 


### PR DESCRIPTION
## Summary

- Adds `typescript` as a `devDependency` to `@resonance/types` and `@resonance/db`, which both run `tsc --noEmit` in their `typecheck` script but were missing the dependency — causing `sh: tsc: command not found` during `pnpm typecheck`.
- All 4 workspace typecheck tasks now pass cleanly.

Closes #29