### PR TITLE
fix(commands): add missing fetch_comments.py reference to OpenCode command

### DIFF
--- a/.opencode/commands/address-pr-comments.md
+++ b/.opencode/commands/address-pr-comments.md
@@ -5,6 +5,12 @@ description: Address unresolved PR review comments for the current branch
 Find the open PR for my current branch and address all unresolved review comments.
 Do not ask me for the PR number -- detect it from the branch using `gh pr view`.
 
+Use the bundled script to fetch comments:
+
+```sh
+python .agents/skills/address-pr-comments/scripts/fetch_comments.py --unresolved-only
+```
+
 For each unresolved comment:
 
 1. **Triage** -- decide whether to fix it or skip it.


### PR DESCRIPTION
## Summary
- Adds the bundled `fetch_comments.py` script reference (with `--unresolved-only` flag) to the OpenCode `address-pr-comments` command, matching the Claude command version.
- Ensures consistent behavior across agent platforms when fetching unresolved PR review comments.

Flagged by kilo-code-bot on PR #34.