### PR TITLE
chore(skills): clarify per-comment GitHub reply requirements

### DIFF
--- a/.agents/skills/address-pr-comments/SKILL.md
+++ b/.agents/skills/address-pr-comments/SKILL.md
@@ -168,7 +168,9 @@ After all comments are addressed, present a summary to the user:
 - How many were filtered out (resolved, outdated, self, bot)
 - How many were fixed (with commit SHAs)
 - How many were skipped (with brief reasons)
-- **For each fix/skip: include which comment databaseId it was replying to**
+- **For each fix/skip: include the identifier for the exact comment addressed**
+  - Review-thread comments: include `databaseId` used with `in_reply_to`
+  - `conversation_comments`: include `COMMENT_URL`/`html_url` used in the issues-comment reply
 
 ## Notes
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major expansion of PR comment-handling docs: adds a CRITICAL per-comment reply requirement, clarifies prerequisites (auth and an open PR), and differentiates inline review comments from general PR discussion.
  * Adds endpoint-selection rules, explicit per-comment identifier usage (databaseId vs comment URL), one-commit-per-comment guidance, updated examples for fixes/skips, a required final summary, and notes on pulling latest changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->