### PR TITLE
feat(steadyhand): optimistic mutation UX for experiences and statuses (#19)

### DIFF
--- a/apps/steadyhand/app/api/applications/[id]/route.ts
+++ b/apps/steadyhand/app/api/applications/[id]/route.ts
@@ -5,6 +5,19 @@ import { auth } from "@/lib/auth";
 
 type RouteParams = { params: Promise<{ id: string }> };
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function invalidIdResponse() {
+  return NextResponse.json(
+    {
+      error: "Validation failed",
+      details: { id: ["Invalid application id"] },
+    },
+    { status: 400 },
+  );
+}
+
 /** GET /api/applications/[id] — get a single application by ID. */
 export async function GET(_req: Request, { params }: RouteParams) {
   const session = await auth();
@@ -14,6 +27,9 @@ export async function GET(_req: Request, { params }: RouteParams) {
   }
 
   const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return invalidIdResponse();
+  }
 
   const [application] = await db
     .select()
@@ -41,6 +57,9 @@ export async function DELETE(_req: Request, { params }: RouteParams) {
   }
 
   const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return invalidIdResponse();
+  }
 
   const [deleted] = await db
     .delete(applications)
@@ -68,6 +87,9 @@ export async function PATCH(req: Request, { params }: RouteParams) {
   }
 
   const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return invalidIdResponse();
+  }
 
   let body: unknown;
   try {

--- a/apps/steadyhand/app/api/applications/[id]/route.ts
+++ b/apps/steadyhand/app/api/applications/[id]/route.ts
@@ -1,59 +1,126 @@
-import { NextResponse } from "next/server"
-import { db, applications, and, eq } from "@resonance/db"
-import { auth } from "@/lib/auth"
+import { NextResponse } from "next/server";
+import { db, applications, and, eq } from "@resonance/db";
+import { updateApplicationSchema } from "@resonance/types";
+import { auth } from "@/lib/auth";
 
-type RouteParams = { params: Promise<{ id: string }> }
+type RouteParams = { params: Promise<{ id: string }> };
 
 /** GET /api/applications/[id] — get a single application by ID. */
 export async function GET(_req: Request, { params }: RouteParams) {
-  const session = await auth()
+  const session = await auth();
 
   if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { id } = await params
+  const { id } = await params;
 
   const [application] = await db
     .select()
     .from(applications)
     .where(
-      and(
-        eq(applications.id, id),
-        eq(applications.userId, session.user.id),
-      ),
-    )
+      and(eq(applications.id, id), eq(applications.userId, session.user.id)),
+    );
 
   if (!application) {
-    return NextResponse.json({ error: "Application not found" }, { status: 404 })
+    return NextResponse.json(
+      { error: "Application not found" },
+      { status: 404 },
+    );
   }
 
-  return NextResponse.json(application)
+  return NextResponse.json(application);
 }
 
 /** DELETE /api/applications/[id] — delete an application. */
 export async function DELETE(_req: Request, { params }: RouteParams) {
-  const session = await auth()
+  const session = await auth();
 
   if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { id } = await params
+  const { id } = await params;
 
   const [deleted] = await db
     .delete(applications)
     .where(
-      and(
-        eq(applications.id, id),
-        eq(applications.userId, session.user.id),
-      ),
+      and(eq(applications.id, id), eq(applications.userId, session.user.id)),
     )
-    .returning({ id: applications.id })
+    .returning({ id: applications.id });
 
   if (!deleted) {
-    return NextResponse.json({ error: "Application not found" }, { status: 404 })
+    return NextResponse.json(
+      { error: "Application not found" },
+      { status: 404 },
+    );
   }
 
-  return new Response(null, { status: 204 })
+  return new Response(null, { status: 204 });
+}
+
+/** PATCH /api/applications/[id] — update application fields (status). */
+export async function PATCH(req: Request, { params }: RouteParams) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        details: { body: ["Invalid JSON body"] },
+      },
+      { status: 400 },
+    );
+  }
+
+  const parsed = updateApplicationSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        details: parsed.error.flatten().fieldErrors,
+      },
+      { status: 400 },
+    );
+  }
+
+  if (!parsed.data.status) {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        details: { status: ["Provide at least one updatable field"] },
+      },
+      { status: 400 },
+    );
+  }
+
+  const [updated] = await db
+    .update(applications)
+    .set({
+      status: parsed.data.status,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(eq(applications.id, id), eq(applications.userId, session.user.id)),
+    )
+    .returning();
+
+  if (!updated) {
+    return NextResponse.json(
+      { error: "Application not found" },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json(updated);
 }

--- a/apps/steadyhand/app/api/applications/[id]/route.ts
+++ b/apps/steadyhand/app/api/applications/[id]/route.ts
@@ -113,7 +113,11 @@ export async function PATCH(req: Request, { params }: RouteParams) {
     .where(
       and(eq(applications.id, id), eq(applications.userId, session.user.id)),
     )
-    .returning();
+    .returning({
+      id: applications.id,
+      status: applications.status,
+      updatedAt: applications.updatedAt,
+    });
 
   if (!updated) {
     return NextResponse.json(

--- a/apps/steadyhand/app/api/applications/[id]/route.ts
+++ b/apps/steadyhand/app/api/applications/[id]/route.ts
@@ -56,7 +56,7 @@ export async function DELETE(_req: Request, { params }: RouteParams) {
     );
   }
 
-  return new Response(null, { status: 204 });
+  return new NextResponse(null, { status: 204 });
 }
 
 /** PATCH /api/applications/[id] — update application fields (status). */

--- a/apps/steadyhand/app/dashboard/applications/[id]/page.tsx
+++ b/apps/steadyhand/app/dashboard/applications/[id]/page.tsx
@@ -2,12 +2,13 @@ import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import type { Application, ApplicationStatus } from "@resonance/types";
+import type { Application } from "@resonance/types";
 import { ParsedJD } from "@/components/applications/ParsedJD";
 import { FitAnalysis } from "@/components/applications/FitAnalysis";
 import { CoverLetterSection } from "@/components/applications/CoverLetterSection";
 import { SelectedBullets } from "@/components/applications/SelectedBullets";
 import { ApplicationTabs } from "@/components/applications/ApplicationTabs";
+import { ApplicationStatusControl } from "@/components/applications/ApplicationStatusControl";
 import {
   EmptyState,
   EmptyStateIcon,
@@ -33,18 +34,6 @@ async function getApplication(id: string): Promise<Application | null> {
     return null;
   }
 }
-
-const statusLabels: Record<ApplicationStatus, string> = {
-  draft: "Draft",
-  ready_to_apply: "Ready to Apply",
-  applied: "Applied",
-  phone_screen: "Phone Screen",
-  technical_interview: "Technical Interview",
-  final_interview: "Final Interview",
-  offer: "Offer",
-  rejected: "Rejected",
-  withdrawn: "Withdrawn",
-};
 
 export async function generateMetadata({
   params,
@@ -138,16 +127,10 @@ export default async function ApplicationDetailPage({
             </div>
 
             {/* Status + actions */}
-            <div className="flex flex-wrap items-center gap-3">
-              <StatusPill
-                status={application.status}
-                label={statusLabels[application.status]}
-              />
-              <button className="flex items-center gap-2 rounded-full border border-border bg-card px-5 py-2 text-sm font-medium text-foreground transition-all hover:bg-muted">
-                <EditIcon className="h-4 w-4" />
-                Edit
-              </button>
-            </div>
+            <ApplicationStatusControl
+              applicationId={application.id}
+              initialStatus={application.status}
+            />
           </div>
         </div>
 
@@ -227,27 +210,6 @@ export default async function ApplicationDetailPage({
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function StatusPill({
-  status,
-  label,
-}: {
-  status: ApplicationStatus;
-  label: string;
-}) {
-  const isActive = !["rejected", "withdrawn"].includes(status);
-  return (
-    <div className="flex items-center gap-2 rounded-full border border-primary/20 bg-secondary px-4 py-1.5 text-sm font-medium text-primary">
-      {isActive && (
-        <span className="relative flex h-2 w-2">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-50" />
-          <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
-        </span>
-      )}
-      {label}
-    </div>
-  );
-}
 
 function formatDate(date: Date | string): string {
   const d = new Date(date);
@@ -335,24 +297,6 @@ function LocationIcon({ className }: { className?: string }) {
     >
       <path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
       <circle cx="12" cy="10" r="3" />
-    </svg>
-  );
-}
-
-function EditIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z" />
-      <path d="m15 5 4 4" />
     </svg>
   );
 }

--- a/apps/steadyhand/app/dashboard/chat/page.tsx
+++ b/apps/steadyhand/app/dashboard/chat/page.tsx
@@ -104,6 +104,22 @@ export default function ChatPage() {
     setExperiences((prev) => prev.filter((item) => item.id !== meta.tempId));
   }
 
+  function restoreDeletedExperience(
+    experienceToRestore: Experience,
+    previousIndex: number,
+  ) {
+    setExperiences((prev) => {
+      if (prev.some((item) => item.id === experienceToRestore.id)) {
+        return prev;
+      }
+      const next = [...prev];
+      const insertIndex =
+        previousIndex < 0 ? prev.length : Math.min(previousIndex, prev.length);
+      next.splice(insertIndex, 0, experienceToRestore);
+      return next;
+    });
+  }
+
   async function handleDelete() {
     if (!deletingExperience) return;
     const experienceToDelete = deletingExperience;
@@ -125,33 +141,11 @@ export default function ChatPage() {
       if (res.ok) {
         toast.success("Experience deleted");
       } else {
-        setExperiences((prev) => {
-          if (prev.some((item) => item.id === experienceToDelete.id)) {
-            return prev;
-          }
-          const next = [...prev];
-          const insertIndex =
-            previousIndex < 0
-              ? prev.length
-              : Math.min(previousIndex, prev.length);
-          next.splice(insertIndex, 0, experienceToDelete);
-          return next;
-        });
+        restoreDeletedExperience(experienceToDelete, previousIndex);
         toast.error("Failed to delete experience. Please try again.");
       }
     } catch {
-      setExperiences((prev) => {
-        if (prev.some((item) => item.id === experienceToDelete.id)) {
-          return prev;
-        }
-        const next = [...prev];
-        const insertIndex =
-          previousIndex < 0
-            ? prev.length
-            : Math.min(previousIndex, prev.length);
-        next.splice(insertIndex, 0, experienceToDelete);
-        return next;
-      });
+      restoreDeletedExperience(experienceToDelete, previousIndex);
       toast.error("Network error — please try again.");
     } finally {
       setDeleteLoading(false);

--- a/apps/steadyhand/app/dashboard/chat/page.tsx
+++ b/apps/steadyhand/app/dashboard/chat/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import type { Experience } from "@resonance/types";
+import type { Experience, ExperienceSaveMeta } from "@resonance/types";
 import { toast } from "sonner";
 import { ChatWindow } from "@/components/chat/ChatWindow";
 import { ExperienceCard } from "@/components/memory/ExperienceCard";
@@ -64,11 +64,7 @@ export default function ChatPage() {
 
   function handleExperienceSaved(
     experience: Experience,
-    meta?: {
-      mode: "create" | "update";
-      optimistic?: boolean;
-      tempId?: string;
-    },
+    meta?: ExperienceSaveMeta,
   ) {
     if (meta?.mode === "create" && meta.optimistic) {
       setExperiences((prev) => [experience, ...prev]);
@@ -95,10 +91,9 @@ export default function ChatPage() {
     }
   }
 
-  function handleExperienceSaveError(meta: {
-    mode: "create" | "update";
-    tempId?: string;
-  }) {
+  function handleExperienceSaveError(
+    meta: Pick<ExperienceSaveMeta, "mode" | "tempId">,
+  ) {
     if (meta.mode !== "create" || !meta.tempId) return;
 
     setExperiences((prev) => prev.filter((item) => item.id !== meta.tempId));

--- a/apps/steadyhand/app/dashboard/chat/page.tsx
+++ b/apps/steadyhand/app/dashboard/chat/page.tsx
@@ -75,6 +75,9 @@ export default function ChatPage() {
       setExperiences((prev) => {
         const index = prev.findIndex((item) => item.id === meta.tempId);
         if (index === -1) {
+          if (prev.some((item) => item.id === experience.id)) {
+            return prev;
+          }
           return [experience, ...prev];
         }
         const next = [...prev];

--- a/apps/steadyhand/app/dashboard/chat/page.tsx
+++ b/apps/steadyhand/app/dashboard/chat/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import type { Experience } from "@resonance/types";
+import { toast } from "sonner";
 import { ChatWindow } from "@/components/chat/ChatWindow";
 import { ExperienceCard } from "@/components/memory/ExperienceCard";
 import { ExperienceForm } from "@/components/memory/ExperienceForm";
@@ -42,7 +43,6 @@ export default function ChatPage() {
   const [deletingExperience, setDeletingExperience] =
     useState<Experience | null>(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const fetchExperiences = useCallback(async () => {
     try {
@@ -62,22 +62,97 @@ export default function ChatPage() {
     fetchExperiences();
   }, [fetchExperiences]);
 
+  function handleExperienceSaved(
+    experience: Experience,
+    meta?: {
+      mode: "create" | "update";
+      optimistic?: boolean;
+      tempId?: string;
+    },
+  ) {
+    if (meta?.mode === "create" && meta.optimistic) {
+      setExperiences((prev) => [experience, ...prev]);
+      return;
+    }
+
+    if (meta?.mode === "create" && meta.tempId) {
+      setExperiences((prev) => {
+        const index = prev.findIndex((item) => item.id === meta.tempId);
+        if (index === -1) {
+          return [experience, ...prev];
+        }
+        const next = [...prev];
+        next[index] = experience;
+        return next;
+      });
+      return;
+    }
+
+    if (meta?.mode === "update") {
+      setExperiences((prev) =>
+        prev.map((item) => (item.id === experience.id ? experience : item)),
+      );
+    }
+  }
+
+  function handleExperienceSaveError(meta: {
+    mode: "create" | "update";
+    tempId?: string;
+  }) {
+    if (meta.mode !== "create" || !meta.tempId) return;
+
+    setExperiences((prev) => prev.filter((item) => item.id !== meta.tempId));
+  }
+
   async function handleDelete() {
     if (!deletingExperience) return;
+    const experienceToDelete = deletingExperience;
+    const previousIndex = experiences.findIndex(
+      (item) => item.id === experienceToDelete.id,
+    );
+
+    setExperiences((prev) =>
+      prev.filter((item) => item.id !== experienceToDelete.id),
+    );
+    setDeletingExperience(null);
     setDeleteLoading(true);
-    setDeleteError(null);
+
     try {
-      const res = await fetch(`/api/experiences/${deletingExperience.id}`, {
+      const res = await fetch(`/api/experiences/${experienceToDelete.id}`, {
         method: "DELETE",
       });
+
       if (res.ok) {
-        setDeletingExperience(null);
-        fetchExperiences();
+        toast.success("Experience deleted");
       } else {
-        setDeleteError("Failed to delete experience. Please try again.");
+        setExperiences((prev) => {
+          if (prev.some((item) => item.id === experienceToDelete.id)) {
+            return prev;
+          }
+          const next = [...prev];
+          const insertIndex =
+            previousIndex < 0
+              ? prev.length
+              : Math.min(previousIndex, prev.length);
+          next.splice(insertIndex, 0, experienceToDelete);
+          return next;
+        });
+        toast.error("Failed to delete experience. Please try again.");
       }
     } catch {
-      setDeleteError("Network error — please try again.");
+      setExperiences((prev) => {
+        if (prev.some((item) => item.id === experienceToDelete.id)) {
+          return prev;
+        }
+        const next = [...prev];
+        const insertIndex =
+          previousIndex < 0
+            ? prev.length
+            : Math.min(previousIndex, prev.length);
+        next.splice(insertIndex, 0, experienceToDelete);
+        return next;
+      });
+      toast.error("Network error — please try again.");
     } finally {
       setDeleteLoading(false);
     }
@@ -125,7 +200,8 @@ export default function ChatPage() {
           <div className="flex items-center gap-3">
             <ResumeUpload onUploaded={fetchExperiences} />
             <ExperienceForm
-              onSaved={fetchExperiences}
+              onSaved={handleExperienceSaved}
+              onSaveError={handleExperienceSaveError}
               trigger={
                 <button className="flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/80">
                   <PlusIcon className="h-4.5 w-4.5" />
@@ -208,10 +284,11 @@ export default function ChatPage() {
           onOpenChange={(open) => {
             if (!open) setEditingExperience(null);
           }}
-          onSaved={() => {
+          onSaved={(experience, meta) => {
+            handleExperienceSaved(experience, meta);
             setEditingExperience(null);
-            fetchExperiences();
           }}
+          onSaveError={handleExperienceSaveError}
         />
       )}
 
@@ -221,7 +298,6 @@ export default function ChatPage() {
         onOpenChange={(open) => {
           if (!open) {
             setDeletingExperience(null);
-            setDeleteError(null);
           }
         }}
       >
@@ -233,9 +309,6 @@ export default function ChatPage() {
               Bank. This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
-          {deleteError && (
-            <p className="text-sm text-destructive">{deleteError}</p>
-          )}
           <AlertDialogFooter>
             <AlertDialogCancel disabled={deleteLoading}>
               Cancel

--- a/apps/steadyhand/app/dashboard/chat/page.tsx
+++ b/apps/steadyhand/app/dashboard/chat/page.tsx
@@ -130,7 +130,6 @@ export default function ChatPage() {
     setExperiences((prev) =>
       prev.filter((item) => item.id !== experienceToDelete.id),
     );
-    setDeletingExperience(null);
     setDeleteLoading(true);
 
     try {
@@ -149,6 +148,7 @@ export default function ChatPage() {
       toast.error("Network error — please try again.");
     } finally {
       setDeleteLoading(false);
+      setDeletingExperience(null);
     }
   }
 

--- a/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
+++ b/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useState, useTransition } from "react";
+import { useEffect, useId, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import type { ApplicationStatus } from "@resonance/types";
 import { toast } from "sonner";
@@ -41,18 +41,28 @@ export function ApplicationStatusControl({
   const statusSelectId = useId();
   const [isPending, startTransition] = useTransition();
   const [status, setStatus] = useState<ApplicationStatus>(initialStatus);
+  const statusRef = useRef<ApplicationStatus>(initialStatus);
+  const latestRequestIdRef = useRef(0);
 
   useEffect(() => {
     setStatus((currentStatus) =>
       currentStatus === initialStatus ? currentStatus : initialStatus,
     );
+    statusRef.current = initialStatus;
   }, [initialStatus]);
+
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
 
   function handleStatusChange(nextStatus: ApplicationStatus) {
     if (nextStatus === status) return;
 
-    const previousStatus = status;
+    const previousStatus = statusRef.current;
     setStatus(nextStatus);
+    statusRef.current = nextStatus;
+    const requestId = latestRequestIdRef.current + 1;
+    latestRequestIdRef.current = requestId;
 
     startTransition(async () => {
       try {
@@ -65,15 +75,20 @@ export function ApplicationStatusControl({
         if (!res.ok) {
           const payload = await res.json().catch(() => null);
           const message = getErrorMessage(payload, "Failed to update status");
+          if (requestId !== latestRequestIdRef.current) return;
           setStatus(previousStatus);
+          statusRef.current = previousStatus;
           toast.error(message);
           return;
         }
 
+        if (requestId !== latestRequestIdRef.current) return;
         toast.success(`Status updated to ${statusLabels[nextStatus]}`);
         router.refresh();
       } catch {
+        if (requestId !== latestRequestIdRef.current) return;
         setStatus(previousStatus);
+        statusRef.current = previousStatus;
         toast.error("Network error while updating status");
       }
     });

--- a/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
+++ b/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
@@ -42,10 +42,10 @@ export function ApplicationStatusControl({
   const [status, setStatus] = useState<ApplicationStatus>(initialStatus);
 
   useEffect(() => {
-    if (status !== initialStatus) {
-      setStatus(initialStatus);
-    }
-  }, [initialStatus, status]);
+    setStatus((currentStatus) =>
+      currentStatus === initialStatus ? currentStatus : initialStatus,
+    );
+  }, [initialStatus]);
 
   function handleStatusChange(nextStatus: ApplicationStatus) {
     if (nextStatus === status) return;

--- a/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
+++ b/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
@@ -29,7 +29,8 @@ export function ApplicationStatusControl({
 }) {
   const router = useRouter();
   const statusSelectId = useId();
-  const [isPending, startTransition] = useTransition();
+  const [, startTransition] = useTransition();
+  const [isSaving, setIsSaving] = useState(false);
   const [status, setStatus] = useState<ApplicationStatus>(initialStatus);
   const statusRef = useRef<ApplicationStatus>(initialStatus);
   const latestRequestIdRef = useRef(0);
@@ -45,7 +46,7 @@ export function ApplicationStatusControl({
     statusRef.current = status;
   }, [status]);
 
-  function handleStatusChange(nextStatus: ApplicationStatus) {
+  async function handleStatusChange(nextStatus: ApplicationStatus) {
     if (nextStatus === status) return;
 
     const previousStatus = statusRef.current;
@@ -54,34 +55,37 @@ export function ApplicationStatusControl({
     const requestId = latestRequestIdRef.current + 1;
     latestRequestIdRef.current = requestId;
 
-    startTransition(async () => {
-      try {
-        const res = await fetch(`/api/applications/${applicationId}`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status: nextStatus }),
-        });
+    setIsSaving(true);
+    try {
+      const res = await fetch(`/api/applications/${applicationId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: nextStatus }),
+      });
 
-        if (!res.ok) {
-          const payload = await res.json().catch(() => null);
-          const message = getErrorMessage(payload, "Failed to update status");
-          if (requestId !== latestRequestIdRef.current) return;
-          setStatus(previousStatus);
-          statusRef.current = previousStatus;
-          toast.error(message);
-          return;
-        }
-
-        if (requestId !== latestRequestIdRef.current) return;
-        toast.success(`Status updated to ${statusLabels[nextStatus]}`);
-        router.refresh();
-      } catch {
+      if (!res.ok) {
+        const payload = await res.json().catch(() => null);
+        const message = getErrorMessage(payload, "Failed to update status");
         if (requestId !== latestRequestIdRef.current) return;
         setStatus(previousStatus);
         statusRef.current = previousStatus;
-        toast.error("Network error while updating status");
+        toast.error(message);
+        return;
       }
-    });
+
+      if (requestId !== latestRequestIdRef.current) return;
+      toast.success(`Status updated to ${statusLabels[nextStatus]}`);
+      startTransition(() => router.refresh());
+    } catch {
+      if (requestId !== latestRequestIdRef.current) return;
+      setStatus(previousStatus);
+      statusRef.current = previousStatus;
+      toast.error("Network error while updating status");
+    } finally {
+      if (requestId === latestRequestIdRef.current) {
+        setIsSaving(false);
+      }
+    }
   }
 
   return (
@@ -97,7 +101,7 @@ export function ApplicationStatusControl({
         onChange={(event) =>
           handleStatusChange(event.target.value as ApplicationStatus)
         }
-        disabled={isPending}
+        disabled={isSaving}
         className="rounded-full border border-border bg-card px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-70"
       >
         {statusOptions.map((option) => (

--- a/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
+++ b/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useId, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import type { ApplicationStatus } from "@resonance/types";
 import { toast } from "sonner";
@@ -38,6 +38,7 @@ export function ApplicationStatusControl({
   initialStatus: ApplicationStatus;
 }) {
   const router = useRouter();
+  const statusSelectId = useId();
   const [isPending, startTransition] = useTransition();
   const [status, setStatus] = useState<ApplicationStatus>(initialStatus);
 
@@ -82,11 +83,11 @@ export function ApplicationStatusControl({
     <div className="flex flex-wrap items-center gap-3">
       <StatusPill status={status} label={statusLabels[status]} />
 
-      <label className="sr-only" htmlFor="application-status-select">
+      <label className="sr-only" htmlFor={statusSelectId}>
         Application status
       </label>
       <select
-        id="application-status-select"
+        id={statusSelectId}
         value={status}
         onChange={(event) =>
           handleStatusChange(event.target.value as ApplicationStatus)

--- a/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
+++ b/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { ApplicationStatus } from "@resonance/types";
+import { toast } from "sonner";
+import { getErrorMessage } from "@/lib/errors";
+
+const statusLabels: Record<ApplicationStatus, string> = {
+  draft: "Draft",
+  ready_to_apply: "Ready to Apply",
+  applied: "Applied",
+  phone_screen: "Phone Screen",
+  technical_interview: "Technical Interview",
+  final_interview: "Final Interview",
+  offer: "Offer",
+  rejected: "Rejected",
+  withdrawn: "Withdrawn",
+};
+
+const statusOptions: ApplicationStatus[] = [
+  "draft",
+  "ready_to_apply",
+  "applied",
+  "phone_screen",
+  "technical_interview",
+  "final_interview",
+  "offer",
+  "rejected",
+  "withdrawn",
+];
+
+export function ApplicationStatusControl({
+  applicationId,
+  initialStatus,
+}: {
+  applicationId: string;
+  initialStatus: ApplicationStatus;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [status, setStatus] = useState<ApplicationStatus>(initialStatus);
+
+  function handleStatusChange(nextStatus: ApplicationStatus) {
+    if (nextStatus === status) return;
+
+    const previousStatus = status;
+    setStatus(nextStatus);
+
+    startTransition(async () => {
+      try {
+        const res = await fetch(`/api/applications/${applicationId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: nextStatus }),
+        });
+
+        if (!res.ok) {
+          const payload = await res.json().catch(() => null);
+          const message = getErrorMessage(payload, "Failed to update status");
+          setStatus(previousStatus);
+          toast.error(message);
+          return;
+        }
+
+        toast.success(`Status updated to ${statusLabels[nextStatus]}`);
+        router.refresh();
+      } catch {
+        setStatus(previousStatus);
+        toast.error("Network error while updating status");
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <StatusPill status={status} label={statusLabels[status]} />
+
+      <label className="sr-only" htmlFor="application-status-select">
+        Application status
+      </label>
+      <select
+        id="application-status-select"
+        value={status}
+        onChange={(event) =>
+          handleStatusChange(event.target.value as ApplicationStatus)
+        }
+        disabled={isPending}
+        className="rounded-full border border-border bg-card px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {statusOptions.map((option) => (
+          <option key={option} value={option}>
+            {statusLabels[option]}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function StatusPill({
+  status,
+  label,
+}: {
+  status: ApplicationStatus;
+  label: string;
+}) {
+  const isActive = !["rejected", "withdrawn"].includes(status);
+  return (
+    <div className="flex items-center gap-2 rounded-full border border-primary/20 bg-secondary px-4 py-1.5 text-sm font-medium text-primary">
+      {isActive && (
+        <span className="relative flex h-2 w-2">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-50" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
+        </span>
+      )}
+      {label}
+    </div>
+  );
+}

--- a/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
+++ b/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import type { ApplicationStatus } from "@resonance/types";
 import { toast } from "sonner";
@@ -40,6 +40,12 @@ export function ApplicationStatusControl({
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [status, setStatus] = useState<ApplicationStatus>(initialStatus);
+
+  useEffect(() => {
+    if (status !== initialStatus) {
+      setStatus(initialStatus);
+    }
+  }, [initialStatus, status]);
 
   function handleStatusChange(nextStatus: ApplicationStatus) {
     if (nextStatus === status) return;

--- a/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
+++ b/apps/steadyhand/components/applications/ApplicationStatusControl.tsx
@@ -6,7 +6,7 @@ import type { ApplicationStatus } from "@resonance/types";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/lib/errors";
 
-const statusLabels: Record<ApplicationStatus, string> = {
+const statusLabels = {
   draft: "Draft",
   ready_to_apply: "Ready to Apply",
   applied: "Applied",
@@ -16,19 +16,9 @@ const statusLabels: Record<ApplicationStatus, string> = {
   offer: "Offer",
   rejected: "Rejected",
   withdrawn: "Withdrawn",
-};
+} satisfies Record<ApplicationStatus, string>;
 
-const statusOptions: ApplicationStatus[] = [
-  "draft",
-  "ready_to_apply",
-  "applied",
-  "phone_screen",
-  "technical_interview",
-  "final_interview",
-  "offer",
-  "rejected",
-  "withdrawn",
-];
+const statusOptions = Object.keys(statusLabels) as ApplicationStatus[];
 
 export function ApplicationStatusControl({
   applicationId,

--- a/apps/steadyhand/components/memory/ExperienceForm.tsx
+++ b/apps/steadyhand/components/memory/ExperienceForm.tsx
@@ -175,8 +175,23 @@ export function ExperienceForm({
       });
 
       if (!res.ok) {
-        const data = await res.json();
-        const message = data.error ?? "Failed to save experience";
+        const fallbackMessage = "Failed to save experience";
+        const textPayload = await res
+          .clone()
+          .text()
+          .then((value) => value.trim())
+          .catch(() => "");
+
+        let message = textPayload || fallbackMessage;
+        try {
+          const data = (await res.json()) as { error?: unknown };
+          if (typeof data.error === "string" && data.error.trim().length > 0) {
+            message = data.error;
+          }
+        } catch {
+          // Keep text payload fallback when response is not valid JSON.
+        }
+
         onSaveError?.({ mode, tempId });
         setError(message);
         toast.error(message);

--- a/apps/steadyhand/components/memory/ExperienceForm.tsx
+++ b/apps/steadyhand/components/memory/ExperienceForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { Experience } from "@resonance/types";
+import type { Experience, ExperienceSaveMeta } from "@resonance/types";
 import { toast } from "sonner";
 import { Button } from "@resonance/ui/components/button";
 import { Input } from "@resonance/ui/components/input";
@@ -36,15 +36,8 @@ export function ExperienceForm({
   experience?: Experience;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  onSaved?: (
-    experience: Experience,
-    meta?: {
-      mode: "create" | "update";
-      optimistic?: boolean;
-      tempId?: string;
-    },
-  ) => void;
-  onSaveError?: (meta: { mode: "create" | "update"; tempId?: string }) => void;
+  onSaved?: (experience: Experience, meta?: ExperienceSaveMeta) => void;
+  onSaveError?: (meta: Pick<ExperienceSaveMeta, "mode" | "tempId">) => void;
   trigger?: React.ReactElement;
 }) {
   const isEditing = !!experience;

--- a/apps/steadyhand/components/memory/ExperienceForm.tsx
+++ b/apps/steadyhand/components/memory/ExperienceForm.tsx
@@ -30,12 +30,21 @@ export function ExperienceForm({
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
   onSaved,
+  onSaveError,
   trigger,
 }: {
   experience?: Experience;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  onSaved?: () => void;
+  onSaved?: (
+    experience: Experience,
+    meta?: {
+      mode: "create" | "update";
+      optimistic?: boolean;
+      tempId?: string;
+    },
+  ) => void;
+  onSaveError?: (meta: { mode: "create" | "update"; tempId?: string }) => void;
   trigger?: React.ReactElement;
 }) {
   const isEditing = !!experience;
@@ -89,6 +98,7 @@ export function ExperienceForm({
     e.preventDefault();
     setError(null);
     setLoading(true);
+    let optimisticTempId: string | undefined;
 
     try {
       const skillsList = skills
@@ -120,6 +130,44 @@ export function ExperienceForm({
             skills: skillsList,
           };
 
+      const mode = experience ? "update" : "create";
+      const tempId =
+        mode === "create" ? `temp-${crypto.randomUUID()}` : undefined;
+      optimisticTempId = tempId;
+
+      if (mode === "create" && tempId) {
+        const trimmedSituation = situation.trim();
+        const trimmedTask = task.trim();
+        const trimmedAction = action.trim();
+        const trimmedResult = result.trim();
+        const hasAnyStarField =
+          trimmedSituation.length > 0 ||
+          trimmedTask.length > 0 ||
+          trimmedAction.length > 0 ||
+          trimmedResult.length > 0;
+
+        onSaved?.(
+          {
+            id: tempId,
+            userId: "optimistic",
+            rawInput,
+            starStructure: hasAnyStarField
+              ? {
+                  situation: trimmedSituation,
+                  task: trimmedTask,
+                  action: trimmedAction,
+                  result: trimmedResult,
+                }
+              : null,
+            skills: skillsList,
+            embedding: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          { mode, optimistic: true, tempId },
+        );
+      }
+
       const res = await fetch(url, {
         method: experience ? "PUT" : "POST",
         headers: { "Content-Type": "application/json" },
@@ -129,16 +177,23 @@ export function ExperienceForm({
       if (!res.ok) {
         const data = await res.json();
         const message = data.error ?? "Failed to save experience";
+        onSaveError?.({ mode, tempId });
         setError(message);
         toast.error(message);
         return;
       }
 
+      const savedExperience = (await res.json()) as Experience;
+
       setOpen(false);
       toast.success("Experience saved to Memory Bank");
-      onSaved?.();
+      onSaved?.(savedExperience, { mode, tempId });
     } catch (error) {
       const message = "Network error — please try again";
+      onSaveError?.({
+        mode: experience ? "update" : "create",
+        tempId: optimisticTempId,
+      });
       setError(message);
       toast.error(message);
       console.error("Save experience error:", error);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -47,6 +47,12 @@ export interface Experience {
   updatedAt: Date;
 }
 
+export type ExperienceSaveMeta = {
+  mode: "create" | "update";
+  optimistic?: boolean;
+  tempId?: string;
+};
+
 export interface TailoredBullet {
   original: string;
   tailored: string;


### PR DESCRIPTION
## Summary
- add `PATCH /api/applications/[id]` to support authenticated status updates with validation
- wire a client-side status control on application detail with optimistic UI, rollback on failure, and refresh on success
- make Memory Bank create/delete feel instant with optimistic insert/remove and reconciliation in chat + form flows

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application status control on application pages with server-side persistence (PATCH)
  * New save metadata type for experience saves

* **Improvements**
  * Optimistic create/update for experiences with temporary IDs and onSaveError callback
  * Optimistic delete with automatic restore on failure and toast notifications
  * Toast notifications added across chat and save/delete flows
  * ID validation and authorization checks for application endpoints

* **Bug Fixes**
  * Revert failed operations and surface clear error toasts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->